### PR TITLE
trip data-test-* attributes in prod build

### DIFF
--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    node: true,
+    browser: false
+  }
+};

--- a/lib/strip-test-selectors/index.js
+++ b/lib/strip-test-selectors/index.js
@@ -1,0 +1,19 @@
+/* eslint-env node */
+'use strict';
+
+const STRIP_ENVIRONMENT = 'production';
+
+module.exports = {
+  name: 'strip-test-selectors',
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  included(app) {
+    if (app.env === STRIP_ENVIRONMENT) {
+      let StripTestSelectorsPlugin = require('./strip-test-selectors');
+      app.registry.add('glimmer-ast-plugin', StripTestSelectorsPlugin);
+    }
+  }
+};

--- a/lib/strip-test-selectors/package.json
+++ b/lib/strip-test-selectors/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "strip-test-selectors",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/lib/strip-test-selectors/strip-test-selectors.js
+++ b/lib/strip-test-selectors/strip-test-selectors.js
@@ -1,0 +1,37 @@
+/* eslint-env node */
+'use strict';
+
+const TEST_SELECTOR_PREFIX = /^data-test-.*/;
+
+function isTestSelector(attribute) {
+  return TEST_SELECTOR_PREFIX.test(attribute);
+}
+
+function filterPairs(pairs) {
+  return pairs.filter(function(pair) {
+    return !isTestSelector(pair.key);
+  });
+}
+
+function filterAttributes(attributes) {
+  return attributes.filter(function(attribute) {
+    return !isTestSelector(attribute.name);
+  });
+}
+
+module.exports = function() {
+  return {
+    name: 'strip-test-selectors',
+    visitor: {
+      ElementNode(node) {
+        node.attributes = filterAttributes(node.attributes);
+      },
+      MustacheStatement(node) {
+        node.hash.pairs = filterPairs(node.hash.pairs);
+      },
+      BlockStatement(node) {
+        node.hash.pairs = filterPairs(node.hash.pairs);
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@glimmer/application": "^0.9.1",
-    "@glimmer/application-pipeline": "^0.11.0",
+    "@glimmer/application-pipeline": "^0.11.1",
     "@glimmer/blueprint": "~0.9.1",
     "@glimmer/component": "^0.9.1",
     "@glimmer/inline-precompile": "^1.0.0",
@@ -45,5 +45,10 @@
   "dependencies": {
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-node-resolve": "^3.3.0"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/strip-test-selectors"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
     debug "^3.1.0"
     walk-sync "^0.3.2"
 
-"@glimmer/application-pipeline@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/application-pipeline/-/application-pipeline-0.11.0.tgz#358bf103b05154569c0da0b567d6a358e31a097a"
+"@glimmer/application-pipeline@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/application-pipeline/-/application-pipeline-0.11.1.tgz#90d83ace1319ee6bd6153f884ad6e3dcc19343af"
   dependencies:
     "@glimmer/app-compiler" "^0.9.0"
     "@glimmer/resolution-map-builder" "^0.5.1"
@@ -42,7 +42,7 @@
     ember-build-utilities "^0.4.0"
     ember-cli-inject-live-reload "^1.4.1"
     ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-preprocess-registry "^3.1.1"
+    ember-cli-preprocess-registry "4.0.0-beta.1"
     ember-cli-string-utils "^1.1.0"
     exists-sync "^0.0.4"
     glob "^7.1.2"
@@ -2297,7 +2297,16 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-preprocess-registry@^3.1.0, ember-cli-preprocess-registry@^3.1.1:
+ember-cli-preprocess-registry@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-4.0.0-beta.1.tgz#94139abd18a48d81a4d475ac0b197776798c892d"
+  dependencies:
+    broccoli-funnel "^1.0.0"
+    broccoli-merge-trees "^1.0.0"
+    debug "^2.2.0"
+    silent-error "^1.0.0"
+
+ember-cli-preprocess-registry@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-3.1.1.tgz#38456c21c4d2b64945850cf9ec68db6ba769288a"
   dependencies:
@@ -4874,10 +4883,6 @@ parseuri@0.0.5:
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
-
-particlesjs@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/particlesjs/-/particlesjs-2.2.2.tgz#1bc4544ded0ba541fe30ced46b8a18a28c9cab8e"
 
 pascalcase@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Since ember-test-selectors does not support Glimmer projects (yet), this is a re-implementation of it in an in-repo-addon.