### PR TITLE
disable non-functional UI in SSR response

### DIFF
--- a/integration-tests/routes/index-test.js
+++ b/integration-tests/routes/index-test.js
@@ -10,6 +10,18 @@ describe('the index route', function() {
         expect(element.length).to.be.ok;
       });
     });
+
+    it('disables the location search field', async function() {
+      await visit('/', async (page, $response) => {
+        expect($response('[data-test-search-input]').is(':disabled')).to.be.true;
+      });
+    });
+
+    it('disables the location search button', async function() {
+      await visit('/', async (page, $response) => {
+        expect($response('[data-test-search-submit]').is(':disabled')).to.be.true;
+      });
+    });
   });
 
   describe('the rehydrated app', function() {

--- a/src/ui/components/Loading/template.hbs
+++ b/src/ui/components/Loading/template.hbs
@@ -1,4 +1,4 @@
-<div class="sk-three-bounce">
+<div class="sk-three-bounce" data-test-loading-spinner>
   <div class="sk-child sk-bounce1"></div>
   <div class="sk-child sk-bounce2"></div>
   <div class="sk-child sk-bounce3"></div>

--- a/src/ui/components/PpmClient/template.hbs
+++ b/src/ui/components/PpmClient/template.hbs
@@ -4,6 +4,7 @@
       @searchTerm={{searchTerm}}
       @store={{store}}
       @router={{router}}
+      @isSSR={{appState.isSSR}}
       @pullIndexedDB={{pullIndexedDB}}
       @searchResults={{searchResults}}
     />

--- a/src/ui/components/Search/template.hbs
+++ b/src/ui/components/Search/template.hbs
@@ -5,7 +5,7 @@
     </h1>
   </header>
 
-  <SearchForm @term={{searchTerm}} @onSearch={{action goToRoute}} />
+  <SearchForm @term={{searchTerm}} @isSSR={{@isSSR}} @onSearch={{action goToRoute}} />
 
   <div class="search-route__results">
     <h2 class="search-route__results__title">

--- a/src/ui/components/SearchForm/component-test.ts
+++ b/src/ui/components/SearchForm/component-test.ts
@@ -11,4 +11,27 @@ module('Component: SearchForm', function(hooks) {
     let inputValue = this.containerElement.querySelector('[data-test-search-input]').value;
     assert.equal(inputValue, 'alpha', 'Term parameter is rendered');
   });
+
+  module('when rendered for SSR', function() {
+    test('it disables the search input field', async function(assert) {
+      await this.render(hbs`<SearchForm @isSSR="true" />`);
+      let element = this.containerElement.querySelector('[data-test-search-input]:disabled');
+
+      assert.ok(element, 'The search input field is disabled');
+    });
+
+    test('it disables the search button', async function(assert) {
+      await this.render(hbs`<SearchForm @isSSR="true" />`);
+      let element = this.containerElement.querySelector('[data-test-search-submit]:disabled');
+
+      assert.ok(element, 'The search button is disabled');
+    });
+
+    test('it renders a loader over the search button', async function(assert) {
+      await this.render(hbs`<SearchForm @isSSR="true" />`);
+      let element = this.containerElement.querySelector('[data-test-search-submit] [data-test-loading-spinner]');
+
+      assert.ok(element, 'A loader is rendered over the search input button');
+    });
+  });
 });

--- a/src/ui/components/SearchForm/template.hbs
+++ b/src/ui/components/SearchForm/template.hbs
@@ -1,6 +1,9 @@
 <form onsubmit={{action submitSearch}} class="search-form">
-  <input value={{search}} oninput={{action updateSearch}} class="search-form__input" data-test-search-input>
-  <button class="search-form__button" data-test-search-submit>
-    Find location
+  <input value={{search}} oninput={{action updateSearch}} placeholder="Enter location" class="search-form__input" disabled={{@isSSR}} data-test-search-input>
+  <button class="search-form__button {{if @isSSR 'loading'}}" disabled={{@isSSR}} data-test-search-submit>
+    {{#if @isSSR}}
+      <Loading />
+    {{/if}}
+    <span>Find location</span>
   </button>
 </form>

--- a/src/ui/styles/_variables.scss
+++ b/src/ui/styles/_variables.scss
@@ -6,6 +6,7 @@ $clear-sky: (
 $font-color: #fff;
 $font-contrast-color: #6a7790;
 $action-color: #2196f7;
+$disabled-color: #75c6ff;
 
 $regular-weight: 400;
 $medium-weight: 500;

--- a/src/ui/styles/components/search-form.scss
+++ b/src/ui/styles/components/search-form.scss
@@ -15,6 +15,10 @@
       border: 2px solid map-get($clear-sky, start);
       outline: none;
     }
+
+    &:disabled {
+      background: rgba($action-color, 0.9);
+    }
   }
   &__button {
     margin-top: 1rem;
@@ -30,6 +34,21 @@
     border: none;
     outline: none;
     cursor: pointer;
+    position: relative;
+
+    &:disabled {
+      .sk-three-bounce {
+        height: 48px;
+        width: 80px;
+        position: absolute;
+        left: calc(50% - 40px);
+        margin: auto 0;
+      }
+
+      span {
+        opacity: .25;
+      }
+    }
   }
 
   @include for-tablet-portrait-up() {


### PR DESCRIPTION
This disabled all UI elements in the SSR response that require the application to be running in the browser to function properly (namely the search form).

closes #43 