### PR TITLE
render search view on /search

### DIFF
--- a/integration-tests/routes/search-test.js
+++ b/integration-tests/routes/search-test.js
@@ -11,6 +11,14 @@ describe('the search route', function() {
       });
     });
 
+    it('is rendered without a search term', async function() {
+      await visit('/search/', async (page, $response) => {
+        let element = $response('[data-test-search]');
+
+        expect(element.length).to.be.ok;
+      });
+    });
+
     it('includes the search result', async function() {
       await visit('/search/Salzburg', async (page, $response) => {
         let element = $response('[data-test-search-result="Salzburg"]');

--- a/src/ui/components/PpmClient/component.ts
+++ b/src/ui/components/PpmClient/component.ts
@@ -108,6 +108,7 @@ export default class PpmClient extends Component {
 
     this.router
       .on('/', () => this._setMode(MODE_SEARCH))
+      .on('/search', () => this._setMode(MODE_SEARCH))
       .on('/search/:searchTerm', (params) => this._setMode(MODE_SEARCH, params))
       .on('/location/:locationId/', (params) => this._setMode(MODE_RESULTS, params))
       .resolve(this.appState.route);

--- a/ssr-server.js
+++ b/ssr-server.js
@@ -70,6 +70,7 @@ async function preprender(req, res, next, data = {orbit: []}) {
 }
 
 app.get('/', preprender);
+app.get('/search', preprender);
 app.get('/search/:searchTerm', async function(req, res, next) {
   try {
     let data = await searchLocation(req.params.searchTerm);


### PR DESCRIPTION
This adds pre-rendering of the app on `/search` (without a search term).