### PR TITLE
Fix loading state for near locations

### DIFF
--- a/src/ui/components/Search/component.ts
+++ b/src/ui/components/Search/component.ts
@@ -106,7 +106,6 @@ export default class Home extends Component {
     let onSuccess = (position) => {
       let { latitude, longitude } = position.coords;
       this.goToRoute(null, [latitude, longitude]);
-      this.loading = false;
     };
     let onError = (e) => {
       this.loading = false;


### PR DESCRIPTION
Currently, we leave the loading state once the location has been retrieved but **before** the API request finishes. This changes that so that the loading state remains until the location has been retrieved and **after** the API request finishes.