### PR TITLE
Don't run fog effect on GPU

### DIFF
--- a/src/ui/components/FogBackground/stylesheet.css
+++ b/src/ui/components/FogBackground/stylesheet.css
@@ -24,7 +24,6 @@
   height: 100%;
   position: absolute;
   width: 200%;
-  will-change: transform;
 }
 
 .image-01, .image-02 {


### PR DESCRIPTION
It seems that in this particular case, it has a negative impact to run the fog effect on the GPU. Whenever I access breethe.app on my iMac, the fans spin up and I just now realized that's because of high GPU load. This move the effect onto the CPU, which does not seem to have a negative effect on performance, also not on mobile devices but stops the fans from spinning up…