### PR TITLE
Calculate dimensions based on content and fix canvas

### DIFF
--- a/src/ui/components/FogBackground/component.ts
+++ b/src/ui/components/FogBackground/component.ts
@@ -3,6 +3,7 @@ import FloatingParticle from './particle';
 
 export default class FogBackground extends Component {
   particles: FloatingParticle[] = [];
+  canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
   fogImage: HTMLImageElement;
 
@@ -38,14 +39,18 @@ export default class FogBackground extends Component {
     let canvas: HTMLCanvasElement = document.querySelector(
       '#ParticlesBackgroundCanvas'
     );
+    let background: HTMLDivElement = document.querySelector(
+      '#ParticlesBackground'
+    );
     let image = await this.loadFogImage();
     let ctx = canvas.getContext('2d');
 
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    canvas.width = background.clientWidth;
+    canvas.height = background.clientHeight;
 
     this.ctx = ctx;
     this.fogImage = image;
+    this.canvas = canvas;
     this.setupParticles(60, canvas.width, canvas.height, image);
     window.requestAnimationFrame(this.drawParticles);
   }
@@ -62,10 +67,10 @@ export default class FogBackground extends Component {
 
   drawParticles = () => {
     let { ctx, particles } = this;
-    let { innerWidth, innerHeight } = window;
+    let { width, height } = this.canvas;
     let opacityFactor = this.opacityForIntensity(this.args.intensity);
 
-    ctx.clearRect(0, 0, innerWidth, innerHeight);
+    ctx.clearRect(0, 0, width, height);
 
     let length = this.particles.length;
     for (let i = 0; i < length; i++) {

--- a/src/ui/components/FogBackground/stylesheet.css
+++ b/src/ui/components/FogBackground/stylesheet.css
@@ -12,3 +12,11 @@
   overflow: hidden;
   background: linear-gradient(map-get($clear-sky, start), map-get($clear-sky, end) 100vH, map-get($clear-sky, end));
 }
+
+.canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}

--- a/src/ui/components/FogBackground/template.hbs
+++ b/src/ui/components/FogBackground/template.hbs
@@ -1,3 +1,3 @@
-<div data-test-fog-background>
-  <canvas id="ParticlesBackgroundCanvas" />
+<div data-test-fog-background id="ParticlesBackground">
+  <canvas id="ParticlesBackgroundCanvas" class='canvas' />
 </div>


### PR DESCRIPTION
So this turned out to be more interesting than what I originally thought. It looks awful at the moment, so I'm sending this PR to tackle the issue quickly using `position: fixed` and calculating the size of the canvas based on the page content instead of the viewport.

I'm experimenting with more sophisticated solutions, as we have to be able to detect when the content size changes. There's a few possible heuristics that we could use but I'm not very convinced about them. I'll note some options in the issue so they can be considered and discussed.  