### PR TITLE
enable immutable caching in production

### DIFF
--- a/ssr-server.js
+++ b/ssr-server.js
@@ -18,6 +18,9 @@ const renderer = new GlimmerRenderer();
 const { SENTRY_DSN } = process.env;
 const USE_SENTRY = !!SENTRY_DSN;
 
+const { ASSET_CACHE_DURATION } = process.env;
+const MAX_ASSET_AGE = ASSET_CACHE_DURATION === 'Infinity' ? Infinity : 0;
+
 if (USE_SENTRY) {
   Raven.config(SENTRY_DSN).install();
 }
@@ -29,7 +32,7 @@ if (USE_SENTRY) {
 }
 
 app.use(morgan('common'));
-app.use(express.static('dist', { index: false }));
+app.use(express.static('dist', { index: false, maxAge: MAX_ASSET_AGE }));
 app.use(requestIp.mw())
 
 async function searchLocation(searchTermOrCoordinates) {


### PR DESCRIPTION
This enables immutable caching of all static assets in production. This mainly only benefits browsers that do not support service workers but support immutable caching as they would no longer have to re-validate assets but just use what they have in their caches.