### PR TITLE
Fix deployment

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -54,7 +54,8 @@ class BreetheGlimmerApp extends GlimmerApp {
           target: 'es6',
           moduleResolution: 'node'
         }
-      }
+      },
+      throwOnError: false
     });
   }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -143,6 +143,9 @@ module.exports = function(defaults) {
     },
     minifyCSS: {
       enabled: process.env.EMBER_ENV === 'production'
+    },
+    fingerprint: {
+      exclude: ['ssr-app.js']
     }
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -42,6 +42,14 @@ function scssPreprocessor(file, data, _configuration, _sourceMap) {
 }
 
 class BreetheGlimmerApp extends GlimmerApp {
+  javascriptTree() {
+    let originalNodeEnv =  process.env.NODE_ENV;
+    process.env.NODE_ENV = null;
+    let result = super.javascriptTree();
+    process.env.NODE_ENV = originalNodeEnv;
+    return result;
+  }
+
   ssrTree() {
     let tsTree = new Funnel('.', {
       include: ['ssr/**/*', 'config/**/*']


### PR DESCRIPTION
The latest Glimmer release seems to ship with broken types which breaks our deployment as broccoli-typescript-compiler throws on compiler errors when the `NODE_ENV` environment variable is `production`.

While of course we should submit a PR to Glimmer fixing the types it ships with, this fixes our deployment for now at least.