### PR TITLE
Stabilize build

### DIFF
--- a/integration-tests/helpers/visit.js
+++ b/integration-tests/helpers/visit.js
@@ -14,13 +14,13 @@ async function visit(route, options, callback) {
   let page = await browser.newPage();
 
   if (options.clientIP) {
-    page.setExtraHTTPHeaders({
+    await page.setExtraHTTPHeaders({
       'X-Client-IP': options.clientIP
     });
   }
 
   if (options.disableJavascript) {
-    page.setJavaScriptEnabled(false);
+    await page.setJavaScriptEnabled(false);
   }
 
   // make sure old service workers are gone…

--- a/integration-tests/nojs-test.js
+++ b/integration-tests/nojs-test.js
@@ -5,13 +5,17 @@ describe('the main flow without javascript', function() {
   it('works', async function() {
     await visit('/', { disableJavascript: true }, async (page) => {
       await page.type('[data-test-search-input]', 'Salzburg');
-      await page.click('[data-test-search-submit]');
-      await page.waitForSelector('[data-test-search-result="Salzburg"]');
+      await Promise.all([
+        page.click('[data-test-search-submit]'),
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' })
+      ]);
 
       expect(page.url()).to.match(/\/search\/Salzburg$/);
 
-      await page.click('[data-test-search-result="Salzburg"] a');
-      await page.waitForSelector('[data-test-location]');
+      await Promise.all([
+        page.click('[data-test-search-result="Salzburg"] a'),
+        page.waitForNavigation()
+      ]);
 
       expect(page.url()).to.match(/\/location\/2$/);
 

--- a/integration-tests/routes/search-test.js
+++ b/integration-tests/routes/search-test.js
@@ -238,8 +238,10 @@ describe('the search route', function() {
     it('allows searching', async function() {
       await visit('/search/', { disableJavascript: true }, async(page, $response) => {
         await page.type('[data-test-search-input]', 'Salzburg');
-        await page.click('[data-test-search-submit]');
-        await page.waitForSelector('[data-test-search-result="Salzburg"]');
+        await Promise.all([
+          page.click('[data-test-search-submit]'),
+          page.waitForNavigation({ waitUntil: 'domcontentloaded' })
+        ]);
 
         expect(page.url()).to.have.path('/search/Salzburg');
       });


### PR DESCRIPTION
This should finally stabilize out Puppeteer tests by:

* awaiting all promises that are returned by the Puppeteer API
* correctly awaiting navigations triggered in tests that run with JS disabled