### PR TITLE
replace file names in manifest as well

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -145,7 +145,8 @@ module.exports = function(defaults) {
       enabled: process.env.EMBER_ENV === 'production'
     },
     fingerprint: {
-      exclude: ['ssr-app.js']
+      exclude: ['ssr-app.js'],
+      replaceExtensions: ['html', 'css', 'js', 'webmanifest']
     }
   });
 


### PR DESCRIPTION
We are now fingerprinting the app images which is good but we're not replacing the file names in the webmanifest which is bad as those are now wrong. This fixes that.