### PR TITLE
rehydrate properly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,23 +8,13 @@ if (typeof Raven !== 'undefined') {
 }
 
 wrapper(() => {
-  const app = new App();
   const containerElement = document.getElementById('app');
+  const hasSSRBody = document.querySelector('[data-has-ssr-response]');
+  const app = new App({ hasSSRBody });
 
   setPropertyDidChange(() => {
     app.scheduleRerender();
   });
-
-  let current = containerElement.firstChild;
-  if (current) {
-    let parent = current.parentElement;
-    let nextNode;
-    do {
-      nextNode = current.nextSibling;
-      parent.removeChild(current);
-      current = nextNode;
-    } while (current);
-  }
 
   app.registerInitializer({
     initialize(registry) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,18 @@
-import Application, { DOMBuilder, RuntimeCompilerLoader, SyncRenderer } from '@glimmer/application';
+import Application, { RehydratingBuilder, DOMBuilder, RuntimeCompilerLoader, SyncRenderer } from '@glimmer/application';
 import Resolver, { BasicModuleRegistry } from '@glimmer/resolver';
 import moduleMap from '../config/module-map';
 import resolverConfiguration from '../config/resolver-configuration';
 
 export default class App extends Application {
-  constructor() {
+  constructor({ hasSSRBody = false }) {
     let moduleRegistry = new BasicModuleRegistry(moduleMap);
     let resolver = new Resolver(resolverConfiguration, moduleRegistry);
     const element = document.body;
 
+    const BuilderType = hasSSRBody ? RehydratingBuilder : DOMBuilder;
+
     super({
-      builder: new DOMBuilder({ element, nextSibling: null }),
+      builder: new BuilderType({ element, nextSibling: null }),
       loader: new RuntimeCompilerLoader(resolver),
       renderer: new SyncRenderer(),
       resolver,

--- a/src/ui/components/Breethe/template.hbs
+++ b/src/ui/components/Breethe/template.hbs
@@ -1,4 +1,4 @@
-<div data-test-breethe>
+<div data-test-breethe data-has-ssr-response={{appState.isSSR}}>
   {{#if showOfflineWarning}}
     <p class="offline-warning" data-test-offline-warning>
       You appear to be offline - searching for locations is available online only.


### PR DESCRIPTION
This uses Glimmer.js' [`RehydratingBuilder`](https://github.com/glimmerjs/glimmer.js/blob/master/packages/@glimmer/application/src/builders/rehydrating-builder.ts) when there is a SSR response body (as it doesn't render anything otherwise) so we do not have to clear out all of the existing DOM and render new when the app boots up in the browser. If we for some reason fail so pre-render on the server (e.g. there could be an error or we might be starting up from the HTML stored in the service worker), we still use the [`DOMBuilder`](https://github.com/glimmerjs/glimmer.js/blob/master/packages/@glimmer/application/src/builders/dom-builder.ts) as the `RehydratingBuilder` would not work in these cases.