### PR TITLE
Fix tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ if (typeof Raven !== 'undefined') {
 wrapper(() => {
   const containerElement = document.getElementById('app');
   const hasSSRBody = document.querySelector('[data-has-ssr-response]');
-  const app = new App({ hasSSRBody: !!hasSSRBody });
+  const app = new App({ hasSSRBody: Boolean(hasSSRBody) });
 
   setPropertyDidChange(() => {
     app.scheduleRerender();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ if (typeof Raven !== 'undefined') {
 wrapper(() => {
   const containerElement = document.getElementById('app');
   const hasSSRBody = document.querySelector('[data-has-ssr-response]');
-  const app = new App({ hasSSRBody });
+  const app = new App({ hasSSRBody: !!hasSSRBody });
 
   setPropertyDidChange(() => {
     app.scheduleRerender();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,8 @@ import moduleMap from '../config/module-map';
 import resolverConfiguration from '../config/resolver-configuration';
 
 export default class App extends Application {
-  constructor({ hasSSRBody = false }) {
+  constructor(options = { hasSSRBody: false }) {
+    let hasSSRBody = options.hasSSRBody;
     let moduleRegistry = new BasicModuleRegistry(moduleMap);
     let resolver = new Resolver(resolverConfiguration, moduleRegistry);
     const element = document.body;

--- a/testem.json
+++ b/testem.json
@@ -1,7 +1,5 @@
 {
-  "framework": "qunit",
-  "src_files": ["src/**/*"],
-  "serve_files": ["index.js"],
+  "test_page": "tests/index.html",
   "disable_watching": true,
   "launch_in_ci": ["Chrome"],
   "launch_in_dev": ["Chrome"],

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Breethe</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.8.0.css">
+    <script src="https://code.jquery.com/qunit/qunit-2.8.0.js"></script>
+    <script src="/testem.js"></script>
+    <script src="./index.js"></script>
+  </head>
+
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="app"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Apparently the way that tests are discovered/run in Glimmer has changed which just silently failed for us as our test suite still passed because it simply didn't run any tests, e.g.: https://travis-ci.org/simplabs/breethe-client/jobs/530182994

This enables the tests again and also fixes an error that had actually made them all fail which we didn't recognize though as the tests never ran.