### PR TITLE
improve lat/lon assertion

### DIFF
--- a/integration-tests/routes/search-test.js
+++ b/integration-tests/routes/search-test.js
@@ -106,7 +106,7 @@ describe('the search route', function() {
 
     it('redirects to coordinates from IP', async function() {
       await visit('/search-by-coordinates', { clientIP: '207.97.227.239'}, async (page, $response) => {
-        expect(page.url()).to.have.path('/search/29.4969,-98.4032');
+        expect(page.url()).to.match(/\/search\/-?\d+(\.\d+)?,-?\d+(\.\d+)?$/);
       });
     });
   });


### PR DESCRIPTION
We are regularly seeing breaking builds due to different lat/lon values in the _"redirects to coordinates from IP"_ test:

```js
it('redirects to coordinates from IP', async function() {
  await visit('/search-by-coordinates', { clientIP: '207.97.227.239'}, async (page, $response) => {
    expect(page.url()).to.match('/search/29.4969,-98.4032');
  });
});
```

I think this happens when geopi changes its data or so and shouldn't actually break the build. In the end we don't want to test the geoip data itself and verify we get the correct location for that sample IP but we want to check that we get redirected to a URL pointing to a lat/lon combination instead of the location name.

This PR changes the test so that we use a regexp for asserting just that instead of relying on an exact set of coordinates.